### PR TITLE
games(meccha-chameleon): link to official community atlas

### DIFF
--- a/crates/website/content/games/meccha-chameleon/meccha-chameleon.md
+++ b/crates/website/content/games/meccha-chameleon/meccha-chameleon.md
@@ -6,3 +6,5 @@ igdb: "405028"
 ---
 
 Pretty fun, it could certainly be improved a lot on the technical level, though
+
+Official site / dev community atlas: [mecchachameleon.art](https://mecchachameleon.art)


### PR DESCRIPTION
Hi @Princesseuh — quick drive-by for the Meccha Chameleon entry.

This adds one outbound link at the bottom of the entry, pointing at the LEMORION-run community atlas (mecchachameleon.art). The atlas tracks patches, maps and player counts for the same developer you played (lemorion_1224 / LEMORION), so it complements the IGDB reference you already have without duplicating it.

Touched:
- crates/website/content/games/meccha-chameleon/meccha-chameleon.md — one new line at the bottom

Not touched:
- frontmatter (title / rating / finishedDate / igdb) — left as-is
- _data.json — auto-generated by the IGDB sync, intentionally skipped
- your review prose — kept verbatim

If you'd rather not have outbound links in the games entries at all, just close this and I'll drop it — no worries. Otherwise happy to tweak wording or move the link elsewhere.