### PR TITLE
fix(collections): use content(catalogue) prefix so new entries deploy

### DIFF
--- a/crates/backend/src/github.rs
+++ b/crates/backend/src/github.rs
@@ -647,7 +647,7 @@ pub async fn commit_collection(token: &str, repo: &str, form: &CollectionForm) -
     let skip_marker_ci = if form.skip_ci { " [skip ci]" } else { "" };
     let skip_marker_cd = if has_new { " [skip cd]" } else { "" };
     let message = format!(
-        "content(collections): Add {}{}{}",
+        "content(catalogue): Add collection {}{}{}",
         form.title, skip_marker_cd, skip_marker_ci
     );
 

--- a/crates/website/src/assets/catalogue.ts
+++ b/crates/website/src/assets/catalogue.ts
@@ -183,6 +183,7 @@ const reviewModalCover = requireElement<HTMLImageElement>("#review-modal-cover")
 const reviewModalMeta = requireElement<Element>("#review-modal-meta");
 const reviewModalCollections = requireElement<HTMLElement>("#review-modal-collections");
 const reviewModalContent = requireElement<Element>("#review-modal-content");
+const reviewModalPromote = requireElement<HTMLButtonElement>("#review-modal-promote");
 
 // `${type}/${diskSlug}` -> collections containing the entry.
 let collectionsIndex: Record<string, CollectionRef[]> = {};
@@ -260,6 +261,21 @@ function updateModalCover(item: CatalogueRecord) {
 	}
 }
 
+function requestPromote(item: CatalogueRecord) {
+	document.dispatchEvent(
+		new CustomEvent("catalogue:promote-request", {
+			detail: {
+				cover: item.cover,
+				slug: slugFromId(item.id, item.type),
+				title: item.title,
+				type: typeToServerType(item.type),
+			},
+		}),
+	);
+}
+
+let modalPromoteHandler: (() => void) | null = null;
+
 function openReviewModal(item: CatalogueRecord) {
 	const titleText = item.releaseYear === null ? item.title : `${item.title} (${item.releaseYear})`;
 	reviewModalTitleLink.textContent = titleText;
@@ -269,6 +285,24 @@ function openReviewModal(item: CatalogueRecord) {
 	renderModalCollections(item, collectionsIndex);
 	reviewModalContent.innerHTML =
 		item.review === "" ? "<p><em>No review written yet.</em></p>" : item.review;
+
+	// The hover promote button on the card is unreachable on touch devices, so
+	// planned entries also get a promote button inside the modal.
+	if (modalPromoteHandler !== null) {
+		reviewModalPromote.removeEventListener("click", modalPromoteHandler);
+		modalPromoteHandler = null;
+	}
+	if (item.status === "planned") {
+		modalPromoteHandler = () => {
+			closeReviewModalFn();
+			requestPromote(item);
+		};
+		reviewModalPromote.addEventListener("click", modalPromoteHandler);
+		reviewModalPromote.classList.remove("hidden");
+	} else {
+		reviewModalPromote.classList.add("hidden");
+	}
+
 	reviewModal.classList.remove("hidden");
 	document.body.style.overflow = "hidden";
 }
@@ -356,16 +390,7 @@ function buildEntryElement(item: CatalogueRecord): HTMLDivElement {
 	if (promoteBtn !== null) {
 		promoteBtn.addEventListener("click", (e) => {
 			e.stopPropagation();
-			document.dispatchEvent(
-				new CustomEvent("catalogue:promote-request", {
-					detail: {
-						cover: item.cover,
-						slug: slugFromId(item.id, item.type),
-						title: item.title,
-						type: typeToServerType(item.type),
-					},
-				}),
-			);
+			requestPromote(item);
 		});
 	}
 	return entry;

--- a/crates/website/src/components/catalogue.rs
+++ b/crates/website/src/components/catalogue.rs
@@ -164,6 +164,7 @@ pub fn review_modal() -> Markup {
                     div class="flex flex-col gap-3 min-w-0" {
                         div id="review-modal-meta" class="flex flex-col gap-y-0.5 text-sm text-subtle-charcoal" {}
                         div id="review-modal-collections" class="empty:hidden flex flex-wrap gap-1 items-center text-sm" {}
+                        button id="review-modal-promote" type="button" class="hidden self-start bg-accent-valencia text-white text-sm font-bold rounded px-3 py-1.5 cursor-pointer hover:bg-accent-valencia/80" { "Mark finished" }
                         div id="review-modal-content" class="prose text-black" {}
                     }
                 }


### PR DESCRIPTION
Creating a collection through the UI can introduce brand-new catalogue
member entries that still need their metadata (covers, dates, etc.)
fetched by the `update-data` workflow. That workflow only fires on
`content(catalogue):` commits, so with the old `content(collections):`
prefix the new members never got their data — and because the commit was
marked `[skip cd]` (a follow-up deploy was expected), it never deployed
either.

Use the `content(catalogue):` prefix for the collection commit so it
triggers `update-data` like any other new catalogue entry: with new
members the follow-up `[ci] update catalogue data` commit drives the
deploy (hence skip cd here), and with no new members there is no
follow-up so the commit deploys itself.