### PR TITLE
feat(scratchmap): fog-of-war reveal over an OSM basemap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,7 +1048,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "graphgarden-core",
- "h3o",
  "lol_html",
  "maud",
  "maudit",

--- a/crates/website/Cargo.toml
+++ b/crates/website/Cargo.toml
@@ -14,4 +14,3 @@ serde_json = { workspace = true }
 xml-builder = "0.6.0"
 lol_html = "2.9.0"
 graphgarden-core = "0.2.0"
-h3o = "0.10.0"

--- a/crates/website/src/assets/scratchmap.ts
+++ b/crates/website/src/assets/scratchmap.ts
@@ -1,50 +1,187 @@
-// Scratch map: a real OpenStreetMap-backed slippy map (CARTO Positron — clean, no
-// business POIs) with the visited H3 hexes drawn on top. Leaflet is bundled from
-// npm; the hex outlines are precomputed at build time and embedded as JSON, so no
-// H3 library is needed in the browser.
+// Scratch map: a fog-of-war over a real OpenStreetMap slippy map (CARTO Positron).
+// The whole world is covered by a solid translucent fog; the H3 cells you've visited
+// are cut out of it, revealing the map beneath. The ONLY hexagon shapes visible are
+// the jagged edges of what you've cleared — there is no hex grid drawn on the fog
+// (that's what makes a small visit never read as "one big hexagon").
+//
+// Layering (bottom → top): base map without labels → fog canvas → labels, so place
+// and street names stay readable on top of the fog. The fog is a single canvas held
+// in its own pane, re-anchored to the viewport each frame so panning stays smooth.
+//
+// The reveal resolution scales with zoom (refining to the stored res 11 up close)
+// but is floored so a clearing stays visible without ballooning when zoomed out.
+// Leaflet + h3-js are bundled from npm.
 
 import * as L from "leaflet";
+import {
+	cellToBoundary,
+	cellToLatLng,
+	cellToParent,
+	getHexagonEdgeLengthAvg,
+	isValidCell,
+	UNITS,
+} from "h3-js";
 
 const el = document.getElementById("scratchmap-map");
-const dataEl = document.getElementById("scratchmap-hexes");
+const dataEl = document.getElementById("scratchmap-cells");
 
 if (el && dataEl) {
-	const hexes = JSON.parse(dataEl.textContent || "[]") as [number, number][][];
+	// Filter to valid H3 indices so a corrupted or tampered cells.json can never
+	// break rendering (h3-js throws on invalid input).
+	const visited = (JSON.parse(dataEl.textContent || "[]") as string[]).filter(isValidCell);
+	const visitedSet = new Set(visited);
 
+	const DATA_RES = 11; // resolution the hexes are stored at
+	const REVEAL_MIN_RES = 7; // coarsest a clearing may get (~1.4 km) when zoomed out
+	const TARGET_HEX_PX = 22; // desired on-screen size of a revealed cell
+
+	const FOG_FILL = "rgba(82, 72, 156, 0.6)"; // violet-ultra
+
+	// Revealed cells at a given resolution (a coarse cell counts as revealed if you
+	// visited any res-11 cell inside it), with their centers cached for cheap
+	// in-viewport filtering.
+	const revealedPtsCache = new Map<number, { cell: string; lat: number; lng: number }[]>();
+	const revealedPtsAt = (res: number) => {
+		let pts = revealedPtsCache.get(res);
+		if (!pts) {
+			const cells =
+				res >= DATA_RES ? visitedSet : new Set(visited.map((c) => cellToParent(c, res)));
+			pts = [...cells].map((cell) => {
+				const [lat, lng] = cellToLatLng(cell);
+				return { cell, lat, lng };
+			});
+			revealedPtsCache.set(res, pts);
+		}
+		return pts;
+	};
+
+	// Zoom animation is disabled on purpose: the fog canvas is drawn in current
+	// container coordinates, which don't track Leaflet's mid-zoom CSS transform.
+	// Instant zoom keeps the fog aligned with the tiles at every step.
 	const map = L.map(el, {
 		zoomControl: false,
-		preferCanvas: true,
-		worldCopyJump: true,
 		minZoom: 2,
+		maxZoom: 19,
+		worldCopyJump: true,
+		zoomAnimation: false,
 	});
 	L.control.zoom({ position: "topright" }).addTo(map);
 
-	L.tileLayer("https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png", {
+	// Panes so labels can render above the fog.
+	map.createPane("fogPane");
+	map.getPane("fogPane")!.style.zIndex = "350";
+	map.getPane("fogPane")!.style.pointerEvents = "none";
+	map.createPane("labelPane");
+	map.getPane("labelPane")!.style.zIndex = "450";
+	map.getPane("labelPane")!.style.pointerEvents = "none";
+
+	L.tileLayer("https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png", {
 		attribution:
 			'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
 		subdomains: "abcd",
-		maxZoom: 20,
+		maxZoom: 19,
 	}).addTo(map);
 
-	// One canvas renderer for all hexes keeps thousands of cells performant.
-	const renderer = L.canvas({ padding: 0.5 });
-	const group = L.featureGroup();
-	for (const ring of hexes) {
-		L.polygon(ring, {
-			renderer,
-			color: "#c73c2e",
-			weight: 1,
-			fillColor: "#c73c2e",
-			fillOpacity: 0.4,
-		}).addTo(group);
-	}
-	group.addTo(map);
+	L.tileLayer("https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}{r}.png", {
+		pane: "labelPane",
+		subdomains: "abcd",
+		maxZoom: 19,
+	}).addTo(map);
 
-	if (hexes.length > 0) {
-		map.fitBounds(group.getBounds(), { padding: [40, 40], maxZoom: 14 });
+	// Pick the reveal resolution: closest to TARGET_HEX_PX at this zoom, floored so a
+	// clearing never balloons, capped at the stored resolution.
+	const revealResForZoom = (): number => {
+		const lat = map.getCenter().lat;
+		const metersPerPixel =
+			(40075016.686 * Math.cos((lat * Math.PI) / 180)) / 2 ** (map.getZoom() + 8);
+		const targetMeters = TARGET_HEX_PX * metersPerPixel;
+		let best = DATA_RES;
+		let bestDiff = Number.POSITIVE_INFINITY;
+		for (let cand = REVEAL_MIN_RES; cand <= DATA_RES; cand++) {
+			const diff = Math.abs(getHexagonEdgeLengthAvg(cand, UNITS.m) - targetMeters);
+			if (diff < bestDiff) {
+				bestDiff = diff;
+				best = cand;
+			}
+		}
+		return best;
+	};
+
+	// Fog canvas in its own pane (below labels). Drawn in container coordinates, so
+	// each draw first cancels the map pane's pan offset to re-anchor to the viewport.
+	const canvas = document.createElement("canvas");
+	canvas.style.position = "absolute";
+	map.getPane("fogPane")!.appendChild(canvas);
+	const ctx = canvas.getContext("2d");
+
+	const draw = () => {
+		if (!ctx) return;
+
+		// Keep the canvas pinned to the viewport despite the pane's pan transform.
+		L.DomUtil.setPosition(canvas, L.DomUtil.getPosition(map.getPanes().mapPane).multiplyBy(-1));
+
+		const size = map.getSize();
+		ctx.clearRect(0, 0, size.x, size.y);
+
+		// 1. Solid fog over everything.
+		ctx.globalCompositeOperation = "source-over";
+		ctx.fillStyle = FOG_FILL;
+		ctx.fillRect(0, 0, size.x, size.y);
+
+		// 2. Cut out the revealed cells (their jagged union is the only hex shape seen).
+		const res = revealResForZoom();
+		const bounds = map.getBounds().pad(0.15);
+		ctx.globalCompositeOperation = "destination-out";
+		for (const pt of revealedPtsAt(res)) {
+			if (!bounds.contains([pt.lat, pt.lng])) continue;
+			const boundary = cellToBoundary(pt.cell);
+			ctx.beginPath();
+			for (let i = 0; i < boundary.length; i++) {
+				const point = map.latLngToContainerPoint([boundary[i][0], boundary[i][1]]);
+				if (i === 0) ctx.moveTo(point.x, point.y);
+				else ctx.lineTo(point.x, point.y);
+			}
+			ctx.closePath();
+			ctx.fill();
+		}
+		ctx.globalCompositeOperation = "source-over";
+	};
+
+	const resize = () => {
+		if (!ctx) return;
+		const size = map.getSize();
+		const dpr = window.devicePixelRatio || 1;
+		canvas.width = size.x * dpr;
+		canvas.height = size.y * dpr;
+		canvas.style.width = `${size.x}px`;
+		canvas.style.height = `${size.y}px`;
+		ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+		draw();
+	};
+
+	// Coalesce the frequent `move` events into one draw per animation frame.
+	let rafPending = false;
+	const scheduleDraw = () => {
+		if (rafPending) return;
+		rafPending = true;
+		requestAnimationFrame(() => {
+			rafPending = false;
+			draw();
+		});
+	};
+
+	map.on("move", scheduleDraw);
+	map.on("zoomend moveend viewreset", draw);
+	map.on("resize", resize);
+
+	if (visited.length > 0) {
+		const points = visited.map((cell) => cellToLatLng(cell) as [number, number]);
+		map.fitBounds(L.latLngBounds(points), { padding: [40, 40], maxZoom: 15 });
 	} else {
-		map.setView([20, 0], 2);
+		map.setView([30, 10], 4);
 	}
+
+	resize();
 }
 
 export {};

--- a/crates/website/src/pages/scratchmap.rs
+++ b/crates/website/src/pages/scratchmap.rs
@@ -1,53 +1,16 @@
-use std::fmt::Write as _;
-
-use h3o::CellIndex;
 use maud::{PreEscaped, html};
 use maudit::{assets::StyleOptions, route::prelude::*};
 
 use crate::layouts::base_layout;
 
-// The only scratch-map state in the repo: a sorted list of visited H3 cell IDs
-// (resolution is set by the Worker on ingest).
+// The only scratch-map state in the repo: a sorted JSON array of visited H3 cell IDs
+// (resolution is set by the Worker on ingest). Passed straight to the client, which
+// draws the fog-of-war overlay with h3-js.
 // `include_str!` (compile-time) ensures cargo rebuilds — and Maudit re-renders — when it changes.
 const CELLS_JSON: &str = include_str!("../../content/scratchmap/cells.json");
 
 // Average area of an H3 resolution-11 cell, in m².
 const RES11_HEX_AREA_M2: f64 = 2150.6;
-
-/// Build a compact JSON array of hex outlines — `[[[lat,lng], …], …]` — one ring
-/// per visited cell, for Leaflet to draw. Antimeridian-straddling hexes are skipped.
-fn hexes_json(cells: &[CellIndex]) -> String {
-    let mut out = String::from("[");
-    let mut first = true;
-    for cell in cells {
-        let boundary = cell.boundary();
-
-        let (mut min_lng, mut max_lng) = (f64::MAX, f64::MIN);
-        for vertex in boundary.iter() {
-            min_lng = min_lng.min(vertex.lng());
-            max_lng = max_lng.max(vertex.lng());
-        }
-        if max_lng - min_lng > 180.0 {
-            continue;
-        }
-
-        if !first {
-            out.push(',');
-        }
-        first = false;
-
-        out.push('[');
-        for (i, vertex) in boundary.iter().enumerate() {
-            if i > 0 {
-                out.push(',');
-            }
-            let _ = write!(out, "[{:.5},{:.5}]", vertex.lat(), vertex.lng());
-        }
-        out.push(']');
-    }
-    out.push(']');
-    out
-}
 
 #[route("/scratchmap/")]
 pub struct ScratchMap;
@@ -62,13 +25,9 @@ impl Route for ScratchMap {
             StyleOptions { tailwind: false },
         )?;
 
-        let cells: Vec<CellIndex> = serde_json::from_str::<Vec<String>>(CELLS_JSON)
-            .unwrap_or_default()
-            .iter()
-            .filter_map(|id| id.parse::<CellIndex>().ok())
-            .collect();
-
-        let count = cells.len();
+        let count = serde_json::from_str::<Vec<String>>(CELLS_JSON)
+            .map(|v| v.len())
+            .unwrap_or(0);
         let area_m2 = count as f64 * RES11_HEX_AREA_M2;
 
         Ok(base_layout(
@@ -80,17 +39,17 @@ impl Route for ScratchMap {
                 div."relative h-[calc(100vh-213px)] md:h-[calc(100vh-255px)]" {
                     div id="scratchmap-map" class="absolute inset-0 bg-white-sugar-cane" {}
 
-                    // Hex outlines for the client to draw over the tiles.
-                    script type="application/json" id="scratchmap-hexes" {
-                        (PreEscaped(hexes_json(&cells)))
+                    // Visited cell IDs for the client to reveal (punch holes in the fog).
+                    script type="application/json" id="scratchmap-cells" {
+                        (PreEscaped(CELLS_JSON.trim()))
                     }
 
                     // Caption overlay, above the map (Leaflet panes/controls sit below z-[1000]).
                     div."absolute top-3 left-3 z-[1000] max-w-xs rounded-sm border border-black-charcoal/10 bg-white-sugar-cane/90 px-3 py-2 pointer-events-none" {
                         h1."text-lg font-semibold leading-tight" { "Scratch map" }
                         p."text-xs text-subtle-charcoal mt-0.5" {
-                            "Everywhere I've physically been, revealed one street-level hexagon "
-                            "(~50 m) at a time. Updated automatically from my phone."
+                            "The world starts fogged. Every ~50 m hexagon I've physically stepped "
+                            "in clears, revealing the map underneath. Updated automatically from my phone."
                         }
                         p."text-xs text-subtle-charcoal font-mono mt-1" {
                             @if count == 0 {
@@ -113,10 +72,7 @@ impl Route for ScratchMap {
 /// Format an area in m², switching to km² once it's large enough to warrant it.
 fn format_area(area_m2: f64) -> String {
     if area_m2 >= 1_000_000.0 {
-        format!(
-            "{} km²",
-            group_digits((area_m2 / 1_000_000.0).round() as u64)
-        )
+        format!("{} km²", group_digits((area_m2 / 1_000_000.0).round() as u64))
     } else {
         format!("{} m²", group_digits(area_m2.round() as u64))
     }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"@tailwindcss/cli": "^4.3.0",
 		"@types/leaflet": "^1.9.21",
 		"github-slugger": "^2.0.0",
+		"h3-js": "^4.5.0",
 		"leaflet": "^1.9.4",
 		"quick-score": "^0.2.0",
 		"tailwindcss": "^4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
+      h3-js:
+        specifier: ^4.5.0
+        version: 4.5.0
       leaflet:
         specifier: ^1.9.4
         version: 1.9.4
@@ -1127,6 +1130,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  h3-js@4.5.0:
+    resolution: {integrity: sha512-uKmdPc+DuarnR+XqZxEuWOMw7KzzKROrx3MLeJpFnMOs78S9M5eZ+X5RieS9UcSFQqbeXzbfWuX/W9Pyajinqw==}
+    engines: {node: '>=4', npm: '>=3', yarn: '>=1.3.0'}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -2350,6 +2357,8 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  h3-js@4.5.0: {}
 
   has-symbols@1.1.0: {}
 


### PR DESCRIPTION
Reworks the scratch map into a fog-of-war: the world is covered by a solid translucent fog, and the H3 cells you've visited are cut out of it, revealing a real OpenStreetMap basemap (CARTO Positron) underneath — with place/street labels layered on top of the fog.

- Rendering moved fully client-side: the page ships the visited cell IDs; Leaflet + h3-js (bundled from npm) draw the fog on a single canvas.
- No hex grid is drawn — the only hexagon shapes are the jagged edges of the cleared area (matches the Bump look).
- Reveal resolution scales with zoom (refining to res 11 up close), floored so a clearing stays visible without ballooning.
- `isValidCell` guards against corrupted/tampered cells.json.
- Drops `h3o` from the website crate (hex geometry now computed in the browser).

Pipeline (Worker → KV → weekly CI → cells.json) is unchanged.