### PR TITLE
feat(scratchmap): district/city/country completion badges

### DIFF
--- a/.github/workflows/update-scratchmap.yml
+++ b/.github/workflows/update-scratchmap.yml
@@ -33,9 +33,12 @@ jobs:
           SCRATCHMAP_TOKEN: ${{ secrets.SCRATCHMAP_TOKEN }}
         run: cargo xtask update-scratchmap --silent
 
+      - name: Compute region completion
+        run: cargo xtask update-regions --silent
+
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "[ci] update scratchmap"
-          file_pattern: crates/website/content/scratchmap/cells.json
+          file_pattern: crates/website/content/scratchmap/*.json
           branch: ${{ github.head_ref }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
 dependencies = [
- "as-slice",
+ "as-slice 0.2.1",
 ]
 
 [[package]]
@@ -138,6 +138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2114736faba96bcd79595c700d03183f61357b9fbce14852515e59f3bee4ed4a"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +189,18 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.9",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "as-slice"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
@@ -207,6 +228,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -738,6 +768,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +997,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "earcutr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
+dependencies = [
+ "itertools 0.11.0",
+ "num-traits",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1218,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28a80e3145d8ad11ba0995949bbcf48b9df2be62772b3d351ef017dff6ecb853"
 
 [[package]]
+name = "float_next_after"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,6 +1342,89 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "geo"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f811f663912a69249fa620dcd2a005db7254529da2d8a0b23942e81f47084501"
+dependencies = [
+ "earcutr",
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "log",
+ "num-traits",
+ "robust",
+ "rstar 0.12.2",
+ "spade",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
+dependencies = [
+ "approx",
+ "num-traits",
+ "rstar 0.10.0",
+ "rstar 0.11.0",
+ "rstar 0.12.2",
+ "rstar 0.8.4",
+ "rstar 0.9.3",
+ "serde",
+]
+
+[[package]]
+name = "geographiclib-rs"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "geojson"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26f3c45b36fccc9cf2805e61d4da6bc4bbd5a3a9589b01afa3a40eff703bd79"
+dependencies = [
+ "geo-types",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1443,6 +1578,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,6 +1657,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heapless"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
+dependencies = [
+ "as-slice 0.1.5",
+ "generic-array 0.14.9",
+ "hash32 0.1.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "rustc_version",
+ "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1755,6 +1952,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -2265,6 +2471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2937,6 +3144,12 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pdqselect"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
 
 [[package]]
 name = "percent-encoding"
@@ -3622,6 +3835,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
 name = "rolldown"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4060,6 +4279,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstar"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a45c0e8804d37e4d97e55c6f258bc9ad9c5ee7b07437009dd152d764949a27c"
+dependencies = [
+ "heapless 0.6.1",
+ "num-traits",
+ "pdqselect",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "rstar"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40f1bfe5acdab44bc63e6699c28b74f75ec43afb59f3eda01e145aff86a25fa"
+dependencies = [
+ "heapless 0.7.17",
+ "num-traits",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "rstar"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f39465655a1e3d8ae79c6d9e007f4953bfc5d55297602df9dc38f9ae9f1359a"
+dependencies = [
+ "heapless 0.7.17",
+ "num-traits",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "rstar"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73111312eb7a2287d229f06c00ff35b51ddee180f017ab6dec1f69d62ac098d6"
+dependencies = [
+ "heapless 0.7.17",
+ "num-traits",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless 0.8.0",
+ "num-traits",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4421,6 +4701,27 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "spade"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
+dependencies = [
+ "hashbrown 0.16.1",
+ "num-traits",
+ "robust",
+ "smallvec",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -5650,8 +5951,11 @@ dependencies = [
  "anyhow",
  "chrono",
  "dotenvy",
+ "geo",
+ "geojson",
  "glob",
  "gray_matter",
+ "h3o",
  "image",
  "oxipng",
  "rayon",

--- a/crates/website/content/scratchmap/regions-cache.json
+++ b/crates/website/content/scratchmap/regions-cache.json
@@ -1,0 +1,26 @@
+{
+  "833960fffffffff": {
+    "osm_id": 2202162,
+    "name": "France",
+    "level": "country",
+    "area": 1207513012894.1865,
+    "lat": 46.603354,
+    "lon": 1.8883335
+  },
+  "8539601bfffffff": {
+    "osm_id": 35738,
+    "name": "Toulouse",
+    "level": "city",
+    "area": 118151855.6827498,
+    "lat": 43.6044638,
+    "lon": 1.4442433
+  },
+  "8739601a1ffffff": {
+    "osm_id": 2344059,
+    "name": "Minimes / Barrière de Paris",
+    "level": "district",
+    "area": 5967010.042567372,
+    "lat": 43.6306577,
+    "lon": 1.4317601
+  }
+}

--- a/crates/website/content/scratchmap/regions.json
+++ b/crates/website/content/scratchmap/regions.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "Toulouse",
+    "level": "city",
+    "lat": 43.6044638,
+    "lon": 1.4442433,
+    "percent": 0.005458169880391939,
+    "explored": 3
+  },
+  {
+    "name": "France",
+    "level": "country",
+    "lat": 46.603354,
+    "lon": 1.8883335,
+    "percent": 5.340670395379926e-7,
+    "explored": 3
+  },
+  {
+    "name": "Minimes / Barrière de Paris",
+    "level": "district",
+    "lat": 43.6306577,
+    "lon": 1.4317601,
+    "percent": 0.10807638924678727,
+    "explored": 3
+  }
+]

--- a/crates/website/src/assets/scratchmap.ts
+++ b/crates/website/src/assets/scratchmap.ts
@@ -174,6 +174,58 @@ if (el && dataEl) {
 	map.on("zoomend moveend viewreset", draw);
 	map.on("resize", resize);
 
+	// --- Completion badges: district / city / country, shown by zoom level ---
+	interface Region {
+		name: string;
+		level: string;
+		lat: number;
+		lon: number;
+		percent: number;
+	}
+	const regionsEl = document.getElementById("scratchmap-regions");
+	const regions: Region[] = regionsEl ? JSON.parse(regionsEl.textContent || "[]") : [];
+
+	// City/country percentages are naturally tiny — show enough decimals to be honest
+	// (this is the "% of the earth you've explored" number) without going scientific.
+	const formatPercent = (p: number): string => {
+		if (p <= 0) return "0%";
+		if (p >= 10) return `${Math.round(p)}%`;
+		if (p >= 1) return `${p.toFixed(1)}%`;
+		const decimals = Math.min(9, Math.max(2, 1 - Math.floor(Math.log10(p))));
+		return `${p.toFixed(decimals)}%`;
+	};
+
+	const levelForZoom = (z: number): string => (z >= 13 ? "district" : z >= 10 ? "city" : "country");
+
+	const badgeLayers: Record<string, L.LayerGroup> = {
+		district: L.layerGroup(),
+		city: L.layerGroup(),
+		country: L.layerGroup(),
+	};
+	for (const region of regions) {
+		const group = badgeLayers[region.level];
+		if (!group) continue;
+		const icon = L.divIcon({
+			className: "",
+			iconSize: [0, 0],
+			iconAnchor: [0, 0],
+			html: `<span style="display:inline-block;transform:translate(-50%,-50%);white-space:nowrap;background:rgba(247,247,247,0.92);border:1px solid rgba(10,9,8,0.12);border-radius:3px;padding:2px 6px;font:600 12px/1.1 system-ui,sans-serif;color:#0a0908;box-shadow:0 1px 2px rgba(0,0,0,0.15)">${region.name} · ${formatPercent(region.percent)}</span>`,
+		});
+		L.marker([region.lat, region.lon], { icon, interactive: false, keyboard: false }).addTo(group);
+	}
+
+	let activeLevel = "";
+	const updateBadges = () => {
+		const level = levelForZoom(map.getZoom());
+		if (level === activeLevel) return;
+		activeLevel = level;
+		for (const [lvl, group] of Object.entries(badgeLayers)) {
+			if (lvl === level) group.addTo(map);
+			else group.remove();
+		}
+	};
+	map.on("zoomend", updateBadges);
+
 	if (visited.length > 0) {
 		const points = visited.map((cell) => cellToLatLng(cell) as [number, number]);
 		map.fitBounds(L.latLngBounds(points), { padding: [40, 40], maxZoom: 15 });
@@ -182,6 +234,7 @@ if (el && dataEl) {
 	}
 
 	resize();
+	updateBadges();
 }
 
 export {};

--- a/crates/website/src/pages/scratchmap.rs
+++ b/crates/website/src/pages/scratchmap.rs
@@ -9,6 +9,9 @@ use crate::layouts::base_layout;
 // `include_str!` (compile-time) ensures cargo rebuilds — and Maudit re-renders — when it changes.
 const CELLS_JSON: &str = include_str!("../../content/scratchmap/cells.json");
 
+// Neighbourhood/city/country completion, computed in CI by `xtask update-regions`.
+const REGIONS_JSON: &str = include_str!("../../content/scratchmap/regions.json");
+
 // Average area of an H3 resolution-11 cell, in m².
 const RES11_HEX_AREA_M2: f64 = 2150.6;
 
@@ -42,6 +45,11 @@ impl Route for ScratchMap {
                     // Visited cell IDs for the client to reveal (punch holes in the fog).
                     script type="application/json" id="scratchmap-cells" {
                         (PreEscaped(CELLS_JSON.trim()))
+                    }
+
+                    // Per-region completion badges, shown by zoom level.
+                    script type="application/json" id="scratchmap-regions" {
+                        (PreEscaped(REGIONS_JSON.trim()))
                     }
 
                     // Caption overlay, above the map (Leaflet panes/controls sit below z-[1000]).

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -20,3 +20,6 @@ dotenvy = "0.15"
 rayon = "1.12"
 chrono = { version = "0.4.44", features = ["serde"] }
 oxipng = { version = "10.1.1", default-features = false, features = ["parallel", "zopfli"] }
+h3o = "0.10.0"
+geo = "0.28.0"
+geojson = { version = "0.24.2", features = ["geo-types"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,6 +16,10 @@ Tasks:
                             merge them into content/scratchmap/cells.json.
                             Requires SCRATCHMAP_TOKEN (and optionally SCRATCHMAP_API).
 
+  update-regions            Reverse-geocode visited cells (via Nominatim) and compute
+                            neighbourhood/city/country completion into
+                            content/scratchmap/regions.json.
+
   export-letterboxd         Generate a Letterboxd-compatible CSV from movie entries.
                             Writes to ./letterboxd-export.csv
 
@@ -58,6 +62,7 @@ fn main() -> anyhow::Result<()> {
         }
         "update-catalogue" => tasks::update_catalogue::run_update_catalogue(),
         "update-scratchmap" => tasks::update_scratchmap::run_update_scratchmap(),
+        "update-regions" => tasks::update_regions::run_update_regions(),
         "export-letterboxd" => {
             let _ = dotenvy::dotenv();
             tasks::export_letterboxd::run_export_letterboxd()

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -5,4 +5,5 @@ pub mod get_info_cover_movie_show;
 pub mod optimize_covers;
 pub mod subset_fonts;
 pub mod update_catalogue;
+pub mod update_regions;
 pub mod update_scratchmap;

--- a/xtask/src/tasks/update_regions.rs
+++ b/xtask/src/tasks/update_regions.rs
@@ -1,0 +1,268 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::thread::sleep;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use geo::{GeodesicArea, MultiPolygon};
+use h3o::{CellIndex, LatLng, Resolution};
+use serde::{Deserialize, Serialize};
+
+use crate::utils::{log_info, log_success, log_warn, workspace_root};
+
+const CELLS_PATH: &str = "crates/website/content/scratchmap/cells.json";
+const REGIONS_PATH: &str = "crates/website/content/scratchmap/regions.json";
+// Persisted geocode results, so weekly runs only hit Nominatim for *new* areas.
+const CACHE_PATH: &str = "crates/website/content/scratchmap/regions-cache.json";
+
+// Average area of an H3 resolution-11 cell, in m².
+const RES11_AREA_M2: f64 = 2149.643;
+
+const USER_AGENT: &str = "erika.florist-scratchmap/1.0 (+https://erika.florist)";
+const NOMINATIM: &str = "https://nominatim.openstreetmap.org/reverse";
+
+// Nominatim's public API asks for max 1 request/second.
+const RATE_LIMIT: Duration = Duration::from_millis(1100);
+
+// (level name, Nominatim reverse `zoom`, H3 resolution to dedupe sample points at).
+// Coarser levels need fewer samples, so we dedupe them harder to save requests.
+const LEVELS: &[(&str, u8, Resolution)] = &[
+    ("district", 14, Resolution::Seven),
+    ("city", 10, Resolution::Five),
+    ("country", 3, Resolution::Three),
+];
+
+#[derive(Serialize)]
+struct Region {
+    name: String,
+    level: String,
+    lat: f64,
+    lon: f64,
+    percent: f64,
+    explored: usize,
+}
+
+/// A geocoded region, cached by the sample cell that produced it. A cache value of
+/// `null` means "looked up, no usable polygon" — so point-only places (common at the
+/// district level) aren't re-queried every week.
+#[derive(Serialize, Deserialize, Clone)]
+struct CachedRegion {
+    osm_id: i64,
+    name: String,
+    level: String,
+    area: f64,
+    lat: f64,
+    lon: f64,
+}
+
+#[derive(Deserialize)]
+struct ReverseResponse {
+    osm_id: Option<i64>,
+    name: Option<String>,
+    lat: Option<String>,
+    lon: Option<String>,
+    #[serde(default)]
+    address: serde_json::Map<String, serde_json::Value>,
+    geojson: Option<serde_json::Value>,
+}
+
+/// Reverse-geocode a point at a given zoom, returning the region (with area) it lands
+/// in, or `None` if there's no polygon to measure.
+fn reverse(lat: f64, lon: f64, zoom: u8, level: &str) -> Result<Option<CachedRegion>> {
+    let url = format!(
+        "{NOMINATIM}?format=jsonv2&lat={lat}&lon={lon}&zoom={zoom}&polygon_geojson=1&addressdetails=1&accept-language=en"
+    );
+    let mut resp: ReverseResponse = ureq::get(&url)
+        .header("User-Agent", USER_AGENT)
+        .call()
+        .context("Nominatim request failed")?
+        .body_mut()
+        .read_json()
+        .context("Nominatim returned unexpected JSON")?;
+
+    let Some(geojson_value) = resp.geojson.take() else {
+        return Ok(None);
+    };
+    let geometry: geojson::Geometry = match serde_json::from_value(geojson_value) {
+        Ok(g) => g,
+        Err(_) => return Ok(None),
+    };
+    let poly: MultiPolygon<f64> = match geo::Geometry::try_from(geometry) {
+        Ok(geo::Geometry::Polygon(p)) => MultiPolygon(vec![p]),
+        Ok(geo::Geometry::MultiPolygon(mp)) => mp,
+        _ => return Ok(None),
+    };
+    let area = poly.geodesic_area_unsigned();
+    if area <= 0.0 {
+        return Ok(None);
+    }
+
+    let name = tidy_name(&region_name(&resp, level));
+    if name.is_empty() {
+        return Ok(None);
+    }
+
+    let plat = resp.lat.and_then(|s| s.parse().ok()).unwrap_or(lat);
+    let plon = resp.lon.and_then(|s| s.parse().ok()).unwrap_or(lon);
+    let osm_id = resp
+        .osm_id
+        .unwrap_or_else(|| (plat * 1000.0) as i64 * 1_000_000 + (plon * 1000.0) as i64);
+
+    Ok(Some(CachedRegion {
+        osm_id,
+        name,
+        level: level.to_string(),
+        area,
+        lat: plat,
+        lon: plon,
+    }))
+}
+
+/// Pick the best display name for a level from Nominatim's address components.
+fn region_name(resp: &ReverseResponse, level: &str) -> String {
+    let addr = |key: &str| {
+        resp.address
+            .get(key)
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+    };
+    let keys: &[&str] = match level {
+        "district" => &[
+            "city_district",
+            "district",
+            "borough",
+            "suburb",
+            "quarter",
+            "neighbourhood",
+        ],
+        "city" => &["city", "town", "municipality", "village"],
+        _ => &["country"],
+    };
+    keys.iter()
+        .find_map(|k| addr(k))
+        .or_else(|| resp.name.clone())
+        .unwrap_or_default()
+}
+
+/// OSM sometimes names a district by concatenating every sub-area with " / "
+/// (e.g. "Minimes / Barrière de Paris / Ponts-Jumeaux / …"). Trim to the first two
+/// for a Bump-style label.
+fn tidy_name(name: &str) -> String {
+    let parts: Vec<&str> = name
+        .split('/')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if parts.len() <= 2 {
+        name.trim().to_string()
+    } else {
+        parts[..2].join(" / ")
+    }
+}
+
+pub fn run_update_regions() -> Result<()> {
+    let root = workspace_root();
+    let regions_path = root.join(REGIONS_PATH);
+    let cache_path = root.join(CACHE_PATH);
+
+    let cells: Vec<CellIndex> = fs::read_to_string(root.join(CELLS_PATH))
+        .ok()
+        .and_then(|s| serde_json::from_str::<Vec<String>>(&s).ok())
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|id| id.parse().ok())
+        .collect();
+
+    if cells.is_empty() {
+        fs::write(&regions_path, "[]\n")?;
+        log_success("No cells yet — wrote empty regions.json.");
+        return Ok(());
+    }
+
+    // Cache maps a sample cell id → its region (or null when there's no polygon).
+    let mut cache: BTreeMap<String, Option<CachedRegion>> = fs::read_to_string(&cache_path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default();
+    let mut cache_dirty = false;
+
+    // Tally visited cells per distinct region, keyed by (level, OSM id).
+    let mut tally: BTreeMap<(String, i64), (CachedRegion, usize)> = BTreeMap::new();
+
+    for (level, zoom, dedupe_res) in LEVELS {
+        // Group cells by coarse parent; keep a count and one real sample cell each.
+        let mut groups: BTreeMap<CellIndex, (usize, CellIndex)> = BTreeMap::new();
+        for cell in &cells {
+            if let Some(parent) = cell.parent(*dedupe_res) {
+                let entry = groups.entry(parent).or_insert((0, *cell));
+                entry.0 += 1;
+            }
+        }
+        let to_geocode = groups
+            .keys()
+            .filter(|k| !cache.contains_key(&k.to_string()))
+            .count();
+        log_info(&format!(
+            "{level}: {} area(s), {to_geocode} new to geocode",
+            groups.len()
+        ));
+
+        for (parent, (count, sample)) in &groups {
+            let key = parent.to_string();
+            if !cache.contains_key(&key) {
+                let ll = LatLng::from(*sample);
+                match reverse(ll.lat(), ll.lng(), *zoom, level) {
+                    Ok(region) => {
+                        cache.insert(key.clone(), region);
+                        cache_dirty = true;
+                    }
+                    // Leave uncached on transient errors so it's retried next run.
+                    Err(e) => log_warn(&format!("  reverse geocode failed for {key}: {e}")),
+                }
+                sleep(RATE_LIMIT);
+            }
+            if let Some(Some(region)) = cache.get(&key) {
+                tally
+                    .entry((region.level.clone(), region.osm_id))
+                    .or_insert_with(|| (region.clone(), 0))
+                    .1 += count;
+            }
+        }
+    }
+
+    let mut regions: Vec<Region> = tally
+        .into_values()
+        .map(|(region, count)| {
+            let percent = (count as f64 * RES11_AREA_M2 / region.area * 100.0).min(100.0);
+            Region {
+                name: region.name,
+                level: region.level,
+                lat: region.lat,
+                lon: region.lon,
+                percent,
+                explored: count,
+            }
+        })
+        .collect();
+    regions.sort_by(|a, b| {
+        a.level
+            .cmp(&b.level)
+            .then(b.percent.partial_cmp(&a.percent).unwrap())
+    });
+
+    fs::write(
+        &regions_path,
+        format!("{}\n", serde_json::to_string_pretty(&regions)?),
+    )?;
+    if cache_dirty {
+        fs::write(
+            &cache_path,
+            format!("{}\n", serde_json::to_string_pretty(&cache)?),
+        )?;
+    }
+    log_success(&format!(
+        "Wrote {} region(s) to regions.json.",
+        regions.len()
+    ));
+    Ok(())
+}


### PR DESCRIPTION
Adds completion badges to the scratch map, shown by zoom level: **district** (zoomed in), **city** (mid), **country** (out).

- New `xtask update-regions`: reverse-geocodes visited cells via **Nominatim** (plain HTTP), grabs each region's polygon, and computes `% = your cells × 50 m ÷ region area`. Writes a small `regions.json`.
- **District**, not neighbourhood: official admin units have polygons almost everywhere (unlike point-only neighbourhoods), and it matches what Bump shows. Six-name OSM blobs are trimmed (e.g. "Minimes / Barrière de Paris").
- **Cached** (`regions-cache.json`): only geocodes *new* areas, so weekly runs make ~zero API calls once you've covered your usual places — sustainable and easy on Nominatim's free server.
- Wired into the weekly `update-scratchmap` workflow; commits all `content/scratchmap/*.json`.
- Frontend shows the right level's badge by zoom (badges layered above the fog + labels).

Country % is intentionally the honest, tiny "% of the country" number (Bump-style).