### PR TITLE
feat(scratchmap): line-fill hexes between consecutive GPS fixes

### DIFF
--- a/crates/backend/src/scratchmap.rs
+++ b/crates/backend/src/scratchmap.rs
@@ -1,15 +1,25 @@
-use h3o::{LatLng, Resolution};
+use h3o::{CellIndex, LatLng, Resolution};
 use serde::Deserialize;
 use worker::*;
 
 const KV_BINDING: &str = "SCRATCHMAP";
 
-/// A location report. OwnTracks location messages use `lat`/`lon`; a plain
-/// `{"lat":..,"lon":..}` body works too. Extra fields (`_type`, `tst`, …) are ignored.
+// Where the previous fix (cell + timestamp) is remembered, so consecutive fixes can
+// be connected. Prefixed with `_` so it's easy to exclude from the cell listing.
+const LAST_KEY: &str = "__last";
+
+// Line-fill guards: connect two fixes only if they're plausibly one continuous walk.
+const MAX_HEX_GAP: i32 = 80; // ~3.5 km — bridge walks/short drives, skip teleports
+const MAX_TIME_GAP: i64 = 600; // seconds — skip gaps where tracking was paused/closed
+
+/// A location report. OwnTracks location messages use `lat`/`lon` (+ `tst`, a unix
+/// timestamp); a plain `{"lat":..,"lon":..}` body works too.
 #[derive(Deserialize)]
 struct LocationPayload {
     lat: f64,
     lon: f64,
+    #[serde(default)]
+    tst: Option<i64>,
 }
 
 /// Shared-secret check for the phone (`?token=`) and CI (`Authorization: Bearer …`).
@@ -41,8 +51,25 @@ fn check_token(req: &Request, env: &Env) -> bool {
     false
 }
 
-/// POST /scratchmap — reduce a location to its H3 res-5 cell and record the cell ID.
-/// Raw coordinates are never stored; the KV key set naturally deduplicates.
+/// Record a cell, writing only if it's new. Most fixes land in already-seen hexes, so
+/// this keeps KV writes (the scarce quota) near zero and spends reads instead.
+async fn store_cell(store: &kv::KvStore, cell: CellIndex) -> Result<()> {
+    let key = cell.to_string();
+    if store.get(&key).text().await?.is_none() {
+        store.put(&key, "1")?.execute().await?;
+    }
+    Ok(())
+}
+
+/// Parse the `"<cell>,<tst>"` value stored under `LAST_KEY`.
+fn parse_last(raw: &str) -> Option<(CellIndex, i64)> {
+    let (cell, tst) = raw.split_once(',')?;
+    Some((cell.parse().ok()?, tst.parse().ok()?))
+}
+
+/// POST /scratchmap — reduce a location to its H3 res-11 cell and record it, plus every
+/// hex along the straight line from the previous fix (so sparse GPS still paints a
+/// continuous trail). Raw coordinates are never stored.
 pub async fn ingest_location(req: &mut Request, env: &Env) -> Result<Response> {
     if !check_token(req, env) {
         return Response::error("Unauthorized", 401);
@@ -61,15 +88,35 @@ pub async fn ingest_location(req: &mut Request, env: &Env) -> Result<Response> {
         Err(_) => return Response::error("Invalid coordinates", 400),
     };
 
-    // Only write hexes we haven't seen before. Since most points fall in
-    // already-visited hexes (home, commute, …), this keeps KV writes — the
-    // scarce quota — near zero once you've covered your usual haunts, spending
-    // the far more plentiful read quota instead.
-    let key = cell.to_string();
-    let kv = env.kv(KV_BINDING)?;
-    if kv.get(&key).text().await?.is_none() {
-        kv.put(&key, "1")?.execute().await?;
+    let now = payload
+        .tst
+        .unwrap_or_else(|| (Date::now().as_millis() / 1000) as i64);
+    let store = env.kv(KV_BINDING)?;
+
+    // Bridge the gap from the previous fix — but only if it looks like one continuous
+    // stretch (close enough, recent enough), never across a drive/flight/app restart.
+    if let Ok(Some(last_raw)) = store.get(LAST_KEY).text().await {
+        if let Some((last_cell, last_tst)) = parse_last(&last_raw) {
+            let dt = now - last_tst;
+            if (0..=MAX_TIME_GAP).contains(&dt) {
+                if let Ok(distance) = last_cell.grid_distance(cell) {
+                    if distance > 1 && distance <= MAX_HEX_GAP {
+                        if let Ok(path) = last_cell.grid_path_cells(cell) {
+                            for step in path.flatten() {
+                                store_cell(&store, step).await?;
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
+
+    store_cell(&store, cell).await?;
+    store
+        .put(LAST_KEY, format!("{cell},{now}"))?
+        .execute()
+        .await?;
 
     // OwnTracks expects a JSON array response (friends / commands); empty is fine.
     Response::from_json(&serde_json::json!([]))
@@ -92,6 +139,10 @@ pub async fn list_cells(req: &Request, env: &Env) -> Result<Response> {
         }
         let result = builder.execute().await?;
         for key in result.keys {
+            // Skip bookkeeping keys like `__last`; only H3 cell ids are cells.
+            if key.name.starts_with('_') {
+                continue;
+            }
             names.push(key.name);
         }
         if result.list_complete {


### PR DESCRIPTION
Fixes gaps in walked trails caused by sparse GPS sampling. When a new fix arrives, the Worker now fills every H3 cell along the straight line from the previous fix to the new one (via `grid_path_cells`), so a continuous walk paints a continuous trail even when the phone only reports every 100–200 m.

Guards so it never draws a false line across a big jump:
- **distance**: skip if the two fixes are more than ~80 hexes (~3.5 km) apart
- **time**: skip if more than 10 min elapsed (tracking was paused/closed)

Stores the previous fix under `__last` (excluded from `/scratchmap/cells`). Still only writes new hexes (KV write quota stays low). Verified locally: two fixes ~500 m apart fill the ~12 hexes between them; an ~11 km jump adds only its own cell.