### PR TITLE
feat(scratchmap): grey stat overlay + fullscreen control

### DIFF
--- a/crates/website/src/assets/scratchmap.ts
+++ b/crates/website/src/assets/scratchmap.ts
@@ -45,6 +45,49 @@ if (el && dataEl) {
 	});
 	L.control.zoom({ position: "topright" }).addTo(map);
 
+	// Fullscreen toggle, styled to sit right under the zoom control.
+	// L.Control.extend is dynamically typed, hence the `any`.
+	const FullscreenControl = (L.Control as any).extend({
+		onAdd() {
+			const bar = L.DomUtil.create("div", "leaflet-bar leaflet-control");
+			const button = L.DomUtil.create("a", "", bar) as HTMLAnchorElement;
+			button.href = "#";
+			button.title = "Toggle fullscreen";
+			button.setAttribute("role", "button");
+			button.innerHTML =
+				'<svg viewBox="0 0 24 24" width="16" height="16" style="display:block;margin:6px auto" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 4H4v4M16 4h4v4M8 20H4v-4M16 20h4v-4"/></svg>';
+			L.DomEvent.on(button, "click", (event) => {
+				L.DomEvent.stop(event);
+				const frame = document.getElementById("scratchmap-frame");
+				if (document.fullscreenElement) document.exitFullscreen();
+				else frame?.requestFullscreen?.();
+			});
+			return bar;
+		},
+	});
+	map.addControl(new FullscreenControl({ position: "topright" }));
+
+	// In fullscreen the frame must fill the screen (its normal height is viewport-minus-header).
+	document.addEventListener("fullscreenchange", () => {
+		const frame = document.getElementById("scratchmap-frame");
+		if (frame) frame.style.height = document.fullscreenElement === frame ? "100%" : "";
+		map.invalidateSize();
+	});
+
+	// Stat overlay — subtle grey text over the map, no card (like the friends-page note).
+	const groupDigits = (n: number) => String(n).replace(/\B(?=(\d{3})+(?!\d))/g, " ");
+	const formatArea = (m2: number) =>
+		m2 >= 1_000_000 ? `${groupDigits(Math.round(m2 / 1_000_000))} km²` : `${groupDigits(m2)} m²`;
+	const stat = document.createElement("div");
+	stat.style.cssText =
+		"position:absolute;left:12px;bottom:10px;z-index:1000;pointer-events:none;font-size:12px;font-variant-numeric:tabular-nums;color:#4d4d4d;text-shadow:0 1px 3px rgba(247,247,247,0.9)";
+	const hexCount = visited.length;
+	stat.textContent =
+		hexCount === 0
+			? "Nothing discovered yet"
+			: `${hexCount} hexagon${hexCount === 1 ? "" : "s"} · ~${formatArea(Math.round(hexCount * 2150.6))}`;
+	el.parentElement?.appendChild(stat);
+
 	// Panes so labels can render above the fog.
 	map.createPane("fogPane");
 	map.getPane("fogPane")!.style.zIndex = "350";

--- a/crates/website/src/pages/scratchmap.rs
+++ b/crates/website/src/pages/scratchmap.rs
@@ -12,9 +12,6 @@ const CELLS_JSON: &str = include_str!("../../content/scratchmap/cells.json");
 // Neighbourhood/city/country completion, computed in CI by `xtask update-regions`.
 const REGIONS_JSON: &str = include_str!("../../content/scratchmap/regions.json");
 
-// Average area of an H3 resolution-11 cell, in m².
-const RES11_HEX_AREA_M2: f64 = 2150.6;
-
 #[route("/scratchmap/")]
 pub struct ScratchMap;
 
@@ -28,18 +25,13 @@ impl Route for ScratchMap {
             StyleOptions { tailwind: false },
         )?;
 
-        let count = serde_json::from_str::<Vec<String>>(CELLS_JSON)
-            .map(|v| v.len())
-            .unwrap_or(0);
-        let area_m2 = count as f64 * RES11_HEX_AREA_M2;
-
         Ok(base_layout(
             Some("Scratch map".into()),
             Some(
                 "A map of everywhere I've physically been, revealed one hexagon at a time.".into(),
             ),
             html!(
-                div."relative h-[calc(100vh-213px)] md:h-[calc(100vh-255px)]" {
+                div id="scratchmap-frame" class="relative h-[calc(100vh-213px)] md:h-[calc(100vh-255px)]" {
                     div id="scratchmap-map" class="absolute inset-0 bg-white-sugar-cane" {}
 
                     // Visited cell IDs for the client to reveal (punch holes in the fog).
@@ -51,23 +43,6 @@ impl Route for ScratchMap {
                     script type="application/json" id="scratchmap-regions" {
                         (PreEscaped(REGIONS_JSON.trim()))
                     }
-
-                    // Caption overlay, above the map (Leaflet panes/controls sit below z-[1000]).
-                    div."absolute top-3 left-3 z-[1000] max-w-xs rounded-sm border border-black-charcoal/10 bg-white-sugar-cane/90 px-3 py-2 pointer-events-none" {
-                        h1."text-lg font-semibold leading-tight" { "Scratch map" }
-                        p."text-xs text-subtle-charcoal mt-0.5" {
-                            "The world starts fogged. Every ~50 m hexagon I've physically stepped "
-                            "in clears, revealing the map underneath. Updated automatically from my phone."
-                        }
-                        p."text-xs text-subtle-charcoal font-mono mt-1" {
-                            @if count == 0 {
-                                "Nothing discovered yet."
-                            } @else {
-                                (count) " hexagon" (if count == 1 { "" } else { "s" })
-                                " · ~" (format_area(area_m2))
-                            }
-                        }
-                    }
                 }
             ),
             true,
@@ -75,27 +50,4 @@ impl Route for ScratchMap {
             ctx,
         ))
     }
-}
-
-/// Format an area in m², switching to km² once it's large enough to warrant it.
-fn format_area(area_m2: f64) -> String {
-    if area_m2 >= 1_000_000.0 {
-        format!("{} km²", group_digits((area_m2 / 1_000_000.0).round() as u64))
-    } else {
-        format!("{} m²", group_digits(area_m2.round() as u64))
-    }
-}
-
-/// Group thousands with a thin space (e.g. `1 234 567`).
-fn group_digits(n: u64) -> String {
-    let digits = n.to_string();
-    let mut out = String::new();
-    let len = digits.len();
-    for (i, ch) in digits.chars().enumerate() {
-        if i > 0 && (len - i).is_multiple_of(3) {
-            out.push('\u{202f}');
-        }
-        out.push(ch);
-    }
-    out
 }


### PR DESCRIPTION
Removes the white caption card. The hexagon/area stat is now subtle grey text bottom-left (computed client-side), and a fullscreen toggle sits under the zoom control.