### PR TITLE
feat(scratchmap): migrate Worker storage from KV to D1

### DIFF
--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-worker = "0.8.3"
+worker = { version = "0.8.3", features = ["d1"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 base64 = "0.22"

--- a/crates/backend/schema.sql
+++ b/crates/backend/schema.sql
@@ -1,0 +1,14 @@
+-- Scratch-map storage. Run once against the D1 database:
+--   wrangler d1 execute scratchmap --remote --file=schema.sql
+
+-- The set of visited H3 res-11 cell IDs. INSERT OR IGNORE dedups, so re-visiting a
+-- cell writes nothing.
+CREATE TABLE IF NOT EXISTS cells (
+    id TEXT PRIMARY KEY
+);
+
+-- Small key/value store; holds `last` = "<cell>,<unix_ts>" for line-fill.
+CREATE TABLE IF NOT EXISTS meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);

--- a/crates/backend/src/scratchmap.rs
+++ b/crates/backend/src/scratchmap.rs
@@ -2,11 +2,7 @@ use h3o::{CellIndex, LatLng, Resolution};
 use serde::Deserialize;
 use worker::*;
 
-const KV_BINDING: &str = "SCRATCHMAP";
-
-// Where the previous fix (cell + timestamp) is remembered, so consecutive fixes can
-// be connected. Prefixed with `_` so it's easy to exclude from the cell listing.
-const LAST_KEY: &str = "__last";
+const D1_BINDING: &str = "SCRATCHMAP_DB";
 
 // Line-fill guards: connect two fixes only if they're plausibly one continuous walk.
 const MAX_HEX_GAP: i32 = 80; // ~3.5 km — bridge walks/short drives, skip teleports
@@ -20,6 +16,11 @@ struct LocationPayload {
     lon: f64,
     #[serde(default)]
     tst: Option<i64>,
+}
+
+#[derive(Deserialize)]
+struct CellRow {
+    id: String,
 }
 
 /// Shared-secret check for the phone (`?token=`) and CI (`Authorization: Bearer …`).
@@ -51,17 +52,7 @@ fn check_token(req: &Request, env: &Env) -> bool {
     false
 }
 
-/// Record a cell, writing only if it's new. Most fixes land in already-seen hexes, so
-/// this keeps KV writes (the scarce quota) near zero and spends reads instead.
-async fn store_cell(store: &kv::KvStore, cell: CellIndex) -> Result<()> {
-    let key = cell.to_string();
-    if store.get(&key).text().await?.is_none() {
-        store.put(&key, "1")?.execute().await?;
-    }
-    Ok(())
-}
-
-/// Parse the `"<cell>,<tst>"` value stored under `LAST_KEY`.
+/// Parse the `"<cell>,<tst>"` value stored under `meta.last`.
 fn parse_last(raw: &str) -> Option<(CellIndex, i64)> {
     let (cell, tst) = raw.split_once(',')?;
     Some((cell.parse().ok()?, tst.parse().ok()?))
@@ -70,6 +61,9 @@ fn parse_last(raw: &str) -> Option<(CellIndex, i64)> {
 /// POST /scratchmap — reduce a location to its H3 res-11 cell and record it, plus every
 /// hex along the straight line from the previous fix (so sparse GPS still paints a
 /// continuous trail). Raw coordinates are never stored.
+///
+/// Stored in D1: `INSERT OR IGNORE` dedups cells server-side (no read-before-write), and
+/// re-visiting a known cell writes nothing — so writes track only newly discovered hexes.
 pub async fn ingest_location(req: &mut Request, env: &Env) -> Result<Response> {
     if !check_token(req, env) {
         return Response::error("Unauthorized", 401);
@@ -91,43 +85,50 @@ pub async fn ingest_location(req: &mut Request, env: &Env) -> Result<Response> {
     let now = payload
         .tst
         .unwrap_or_else(|| (Date::now().as_millis() / 1000) as i64);
-    let store = env.kv(KV_BINDING)?;
+    let db = env.d1(D1_BINDING)?;
 
-    let last = match store.get(LAST_KEY).text().await {
-        Ok(Some(raw)) => parse_last(&raw),
-        _ => None,
-    };
+    let last_raw: Option<String> = db
+        .prepare("SELECT value FROM meta WHERE key = 'last'")
+        .first(Some("value"))
+        .await?;
+    let last = last_raw.as_deref().and_then(parse_last);
 
-    // Still in the same 50 m cell as the previous fix → already recorded, so write
-    // nothing. This is the common case for frequent pings (stationary or slow), and
-    // skipping it keeps KV *writes* — the scarce free-tier quota — down to roughly one
-    // per cell you actually move into.
+    // Still in the same 50 m cell as the previous fix → already recorded, nothing to do.
     if last.map(|(last_cell, _)| last_cell) == Some(cell) {
         return Response::from_json(&serde_json::json!([]));
     }
 
-    // Bridge the gap from the previous fix — but only if it looks like one continuous
-    // stretch (close enough, recent enough), never across a drive/flight/app restart.
+    // Gather the cells to record: the current one, plus the straight line from the
+    // previous fix — but only if it looks like one continuous stretch (close enough,
+    // recent enough), never across a drive/flight/app restart.
+    let mut cells = Vec::new();
     if let Some((last_cell, last_tst)) = last {
         let dt = now - last_tst;
         if (0..=MAX_TIME_GAP).contains(&dt) {
             if let Ok(distance) = last_cell.grid_distance(cell) {
                 if distance > 1 && distance <= MAX_HEX_GAP {
                     if let Ok(path) = last_cell.grid_path_cells(cell) {
-                        for step in path.flatten() {
-                            store_cell(&store, step).await?;
-                        }
+                        cells.extend(path.flatten());
                     }
                 }
             }
         }
     }
+    cells.push(cell);
 
-    store_cell(&store, cell).await?;
-    store
-        .put(LAST_KEY, format!("{cell},{now}"))?
-        .execute()
-        .await?;
+    // One atomic batch: record every cell (dedup via INSERT OR IGNORE) and move `last`.
+    let mut statements = Vec::with_capacity(cells.len() + 1);
+    for cell in &cells {
+        statements.push(
+            db.prepare("INSERT OR IGNORE INTO cells (id) VALUES (?1)")
+                .bind(&[cell.to_string().into()])?,
+        );
+    }
+    statements.push(
+        db.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES ('last', ?1)")
+            .bind(&[format!("{cell},{now}").into()])?,
+    );
+    db.batch(statements).await?;
 
     // OwnTracks expects a JSON array response (friends / commands); empty is fine.
     Response::from_json(&serde_json::json!([]))
@@ -139,32 +140,13 @@ pub async fn list_cells(req: &Request, env: &Env) -> Result<Response> {
         return Response::error("Unauthorized", 401);
     }
 
-    let kv = env.kv(KV_BINDING)?;
-    let mut names = Vec::new();
-    let mut cursor: Option<String> = None;
+    let db = env.d1(D1_BINDING)?;
+    let result = db.prepare("SELECT id FROM cells ORDER BY id").all().await?;
+    let names: Vec<String> = result
+        .results::<CellRow>()?
+        .into_iter()
+        .map(|row| row.id)
+        .collect();
 
-    loop {
-        let mut builder = kv.list();
-        if let Some(cursor) = cursor.take() {
-            builder = builder.cursor(cursor);
-        }
-        let result = builder.execute().await?;
-        for key in result.keys {
-            // Skip bookkeeping keys like `__last`; only H3 cell ids are cells.
-            if key.name.starts_with('_') {
-                continue;
-            }
-            names.push(key.name);
-        }
-        if result.list_complete {
-            break;
-        }
-        cursor = result.cursor;
-        if cursor.is_none() {
-            break;
-        }
-    }
-
-    names.sort();
     Response::from_json(&names)
 }

--- a/crates/backend/wrangler.toml
+++ b/crates/backend/wrangler.toml
@@ -13,7 +13,7 @@ ALLOWED_ORIGINS = "erika.florist"
 [[d1_databases]]
 binding = "SCRATCHMAP_DB"
 database_name = "scratchmap"
-database_id = "REPLACE_WITH_D1_DATABASE_ID"
+database_id = "02d83bfb-faa2-4384-a64f-c7b293347a9c"
 
 [env.dev.vars]
 ALLOWED_ORIGINS = "localhost,127.0.0.1,erika.florist"

--- a/crates/backend/wrangler.toml
+++ b/crates/backend/wrangler.toml
@@ -7,10 +7,13 @@ ALLOWED_ORIGINS = "erika.florist"
 
 # Accumulates visited H3 res-11 cell IDs for the scratch map. Only cell IDs are
 # stored here — raw coordinates are reduced to a hex on ingest and discarded.
-# Create with: wrangler kv namespace create SCRATCHMAP
-[[kv_namespaces]]
-binding = "SCRATCHMAP"
-id = "ac7ae6f30a974421b0e4dfe138154f23"
+# Setup:
+#   wrangler d1 create scratchmap                 # paste the id below
+#   wrangler d1 execute scratchmap --remote --file=schema.sql
+[[d1_databases]]
+binding = "SCRATCHMAP_DB"
+database_name = "scratchmap"
+database_id = "REPLACE_WITH_D1_DATABASE_ID"
 
 [env.dev.vars]
 ALLOWED_ORIGINS = "localhost,127.0.0.1,erika.florist"


### PR DESCRIPTION
Moves the scratch-map Worker's storage from Workers KV to D1 (SQL), whose free tier allows ~100k writes/day (~100× KV) — so heavy travel days no longer risk the daily write limit.

- Cells live in a `cells (id PRIMARY KEY)` table; `INSERT OR IGNORE` dedups server-side (no read-before-write), and re-visiting a known cell writes nothing.
- Line-fill's previous-fix pointer moves to a `meta (key, value)` table.
- Same external API (`POST /scratchmap`, `GET /scratchmap/cells`), so OwnTracks and the CI sync are unchanged.

**Requires setup before merge/deploy** (the deploy fails with a placeholder database_id):
1. `cd crates/backend && npx wrangler d1 create scratchmap` → put the id in wrangler.toml
2. `npx wrangler d1 execute scratchmap --remote --file=schema.sql`
3. GitHub `SCRATCHMAP_TOKEN` secret is unchanged.

Existing hexes aren't lost: cells.json in the repo already holds them, and the weekly CI unions the (now D1-sourced) set into it.